### PR TITLE
feat: Implement User CRUD operations and add initial user data

### DIFF
--- a/src/main/java/br/com/gustavobarbozamarques/controllers/UserController.java
+++ b/src/main/java/br/com/gustavobarbozamarques/controllers/UserController.java
@@ -1,0 +1,75 @@
+package br.com.gustavobarbozamarques.controllers;
+
+import br.com.gustavobarbozamarques.dto.UserRequestDTO;
+import br.com.gustavobarbozamarques.dto.UserResponseDTO;
+import br.com.gustavobarbozamarques.services.UserService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import java.util.List;
+
+@Api(tags = "User Catalog")
+@RestController
+@Validated
+@RequestMapping(path = "/v1/users")
+public class UserController {
+
+    @Autowired
+    private UserService userService;
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation("Get all users.")
+    public List<UserResponseDTO> listAll() {
+        return userService.listAll();
+    }
+
+    @GetMapping("/{userId}")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation("Get user by id.")
+    public UserResponseDTO listById(
+            @PathVariable("userId") @Min(value = 1, message = "Invalid userId value.") Integer userId
+    ) {
+        return userService.listById(userId);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation("Save new user.")
+    public UserResponseDTO save(@Valid @RequestBody UserRequestDTO userRequestDTO) {
+        return userService.save(userRequestDTO);
+    }
+
+    @PutMapping("/{userId}")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation("Update user by id.")
+    public UserResponseDTO update(
+            @PathVariable("userId") @Min(value = 1, message = "Invalid userId value.") Integer userId,
+            @Valid @RequestBody UserRequestDTO userRequestDTO
+    ) {
+        return userService.update(userId, userRequestDTO);
+    }
+
+    @DeleteMapping("/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiOperation("Delete user by id.")
+    public void delete(
+            @PathVariable("userId") @Min(value = 1, message = "Invalid userId value.") Integer userId
+    ) {
+        userService.delete(userId);
+    }
+}

--- a/src/main/java/br/com/gustavobarbozamarques/dto/UserRequestDTO.java
+++ b/src/main/java/br/com/gustavobarbozamarques/dto/UserRequestDTO.java
@@ -1,0 +1,30 @@
+package br.com.gustavobarbozamarques.dto;
+
+import br.com.gustavobarbozamarques.entities.User;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@Data
+@Builder
+public class UserRequestDTO {
+    @NotBlank(message = "Name cannot be blank.")
+    private String name;
+
+    @NotBlank(message = "Email cannot be blank.")
+    @Email(message = "Invalid email format.")
+    private String email;
+
+    @NotBlank(message = "Password cannot be blank.")
+    private String password;
+
+    public static User from(UserRequestDTO request) {
+        return User.builder()
+                .name(request.getName())
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .build();
+    }
+}

--- a/src/main/java/br/com/gustavobarbozamarques/dto/UserResponseDTO.java
+++ b/src/main/java/br/com/gustavobarbozamarques/dto/UserResponseDTO.java
@@ -1,0 +1,25 @@
+package br.com.gustavobarbozamarques.dto;
+
+import br.com.gustavobarbozamarques.entities.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseDTO {
+    private Integer id;
+    private String name;
+    private String email;
+
+    public static UserResponseDTO from(User user) {
+        return UserResponseDTO.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/br/com/gustavobarbozamarques/entities/User.java
+++ b/src/main/java/br/com/gustavobarbozamarques/entities/User.java
@@ -1,0 +1,34 @@
+package br.com.gustavobarbozamarques.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(generator = "user_seq_generator")
+    @SequenceGenerator(name = "user_seq_generator", sequenceName = "user_seq", allocationSize = 1)
+    private Integer id;
+
+    private String name;
+
+    @Column(unique = true)
+    private String email;
+
+    private String password;
+}

--- a/src/main/java/br/com/gustavobarbozamarques/repositories/UserRepository.java
+++ b/src/main/java/br/com/gustavobarbozamarques/repositories/UserRepository.java
@@ -1,0 +1,8 @@
+package br.com.gustavobarbozamarques.repositories;
+
+import br.com.gustavobarbozamarques.entities.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+    User findByEmail(String email);
+}

--- a/src/main/java/br/com/gustavobarbozamarques/services/UserService.java
+++ b/src/main/java/br/com/gustavobarbozamarques/services/UserService.java
@@ -1,0 +1,62 @@
+package br.com.gustavobarbozamarques.services;
+
+import br.com.gustavobarbozamarques.dto.UserRequestDTO;
+import br.com.gustavobarbozamarques.dto.UserResponseDTO;
+import br.com.gustavobarbozamarques.entities.User;
+import br.com.gustavobarbozamarques.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public List<UserResponseDTO> listAll() {
+        return userRepository.findAll()
+                .stream()
+                .map(UserResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    public UserResponseDTO listById(Integer id) {
+        User user = findById(id);
+        return UserResponseDTO.from(user);
+    }
+
+    public UserResponseDTO save(UserRequestDTO userRequestDTO) {
+        User user = UserRequestDTO.from(userRequestDTO);
+        // TODO: Implement password encoding before saving
+        User savedUser = userRepository.save(user);
+        return UserResponseDTO.from(savedUser);
+    }
+
+    public UserResponseDTO update(Integer id, UserRequestDTO userRequestDTO) {
+        User user = findById(id);
+        user.setName(userRequestDTO.getName());
+        user.setEmail(userRequestDTO.getEmail());
+        // TODO: Implement password encoding before updating
+        user.setPassword(userRequestDTO.getPassword());
+        User updatedUser = userRepository.save(user);
+        return UserResponseDTO.from(updatedUser);
+    }
+
+    public void delete(Integer id) {
+        findById(id); // Check if user exists before deleting
+        userRepository.deleteById(id);
+    }
+
+    private User findById(Integer id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id " + id));
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -10,3 +10,8 @@ insert into products (category_id, description, name, price, id) values (1, 'Not
 insert into products (category_id, description, name, price, id) values (2, 'Watch Bronze', 'Watch Bronze 300g', 500, nextval('product_seq'));
 insert into products (category_id, description, name, price, id) values (2, 'Watch Silver', 'Watch Silver 400g', 700, nextval('product_seq'));
 insert into products (category_id, description, name, price, id) values (2, 'Watch Gold', 'Watch Gold 500g', 900, nextval('product_seq'));
+
+--users
+insert into users (name, email, password, id) values ('John Doe', 'john.doe@example.com', 'password123', nextval('user_seq'));
+insert into users (name, email, password, id) values ('Jane Smith', 'jane.smith@example.com', 'securepass', nextval('user_seq'));
+insert into users (name, email, password, id) values ('Peter Jones', 'peter.jones@example.com', 'mysecret', nextval('user_seq'));

--- a/src/test/java/br/com/gustavobarbozamarques/controllers/UserControllerTest.java
+++ b/src/test/java/br/com/gustavobarbozamarques/controllers/UserControllerTest.java
@@ -1,0 +1,150 @@
+package br.com.gustavobarbozamarques.controllers;
+
+import br.com.gustavobarbozamarques.dto.UserRequestDTO;
+import br.com.gustavobarbozamarques.dto.UserResponseDTO;
+import br.com.gustavobarbozamarques.mocks.UserRequestDTOMock;
+import br.com.gustavobarbozamarques.mocks.UserMock;
+import br.com.gustavobarbozamarques.services.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testListAllShouldReturnOkAndUserList() throws Exception {
+        var userList = List.of(UserMock.get());
+        when(userService.listAll()).thenReturn(userList.stream().map(UserResponseDTO::from).collect(java.util.stream.Collectors.toList()));
+
+        mockMvc.perform(get("/v1/users"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(userList.get(0).getId()));
+    }
+
+    @Test
+    void testListAllShouldReturnOkAndEmptyList() throws Exception {
+        when(userService.listAll()).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/v1/users"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void testListByIdShouldReturnOkWhenFound() throws Exception {
+        var user = UserMock.get();
+        when(userService.listById(user.getId())).thenReturn(UserResponseDTO.from(user));
+
+        mockMvc.perform(get("/v1/users/{id}", user.getId()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(user.getId()));
+    }
+
+    @Test
+    void testListByIdShouldReturnNotFoundWhenNotExists() throws Exception {
+        int userId = 1;
+        when(userService.listById(userId)).thenThrow(new EntityNotFoundException());
+
+        mockMvc.perform(get("/v1/users/{id}", userId))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testListByIdShouldReturnBadRequestWhenInvalidId() throws Exception {
+        mockMvc.perform(get("/v1/users/{id}", "invalid-id"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testSaveShouldReturnCreatedWhenPayloadIsValid() throws Exception {
+        var userRequestDTO = UserRequestDTOMock.get();
+        var userResponseDTO = UserResponseDTO.from(UserMock.get());
+        when(userService.save(any(UserRequestDTO.class))).thenReturn(userResponseDTO);
+
+        mockMvc.perform(post("/v1/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userRequestDTO)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(userResponseDTO.getId()));
+    }
+
+    @Test
+    void testUpdateShouldReturnOkWhenPayloadIsValid() throws Exception {
+        int userId = 1;
+        var userRequestDTO = UserRequestDTOMock.get();
+        var userResponseDTO = UserResponseDTO.from(UserMock.get());
+        when(userService.update(eq(userId), any(UserRequestDTO.class))).thenReturn(userResponseDTO);
+
+        mockMvc.perform(put("/v1/users/{id}", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userRequestDTO)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(userResponseDTO.getId()));
+    }
+
+    @Test
+    void testUpdateShouldReturnNotFoundWhenNotExists() throws Exception {
+        int userId = 1;
+        var userRequestDTO = UserRequestDTOMock.get();
+        when(userService.update(eq(userId), any(UserRequestDTO.class))).thenThrow(new EntityNotFoundException());
+
+        mockMvc.perform(put("/v1/users/{id}", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userRequestDTO)))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testDeleteShouldReturnNoContentWhenSuccessful() throws Exception {
+        int userId = 1;
+        doNothing().when(userService).delete(userId);
+
+        mockMvc.perform(delete("/v1/users/{id}", userId))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void testDeleteShouldReturnNotFoundWhenNotExists() throws Exception {
+        int userId = 1;
+        doThrow(new EntityNotFoundException()).when(userService).delete(userId);
+
+        mockMvc.perform(delete("/v1/users/{id}", userId))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/br/com/gustavobarbozamarques/mocks/UserMock.java
+++ b/src/test/java/br/com/gustavobarbozamarques/mocks/UserMock.java
@@ -1,0 +1,14 @@
+package br.com.gustavobarbozamarques.mocks;
+
+import br.com.gustavobarbozamarques.entities.User;
+
+public class UserMock {
+    public static User get() {
+        return User.builder()
+                .id(1)
+                .name("Test User")
+                .email("test@example.com")
+                .password("password123")
+                .build();
+    }
+}

--- a/src/test/java/br/com/gustavobarbozamarques/mocks/UserRequestDTOMock.java
+++ b/src/test/java/br/com/gustavobarbozamarques/mocks/UserRequestDTOMock.java
@@ -1,0 +1,13 @@
+package br.com.gustavobarbozamarques.mocks;
+
+import br.com.gustavobarbozamarques.dto.UserRequestDTO;
+
+public class UserRequestDTOMock {
+    public static UserRequestDTO get() {
+        return UserRequestDTO.builder()
+                .name("Test User")
+                .email("test@example.com")
+                .password("password123")
+                .build();
+    }
+}

--- a/src/test/java/br/com/gustavobarbozamarques/services/UserServiceTest.java
+++ b/src/test/java/br/com/gustavobarbozamarques/services/UserServiceTest.java
@@ -1,0 +1,116 @@
+package br.com.gustavobarbozamarques.services;
+
+import br.com.gustavobarbozamarques.dto.UserRequestDTO;
+import br.com.gustavobarbozamarques.entities.User;
+import br.com.gustavobarbozamarques.mocks.UserMock;
+import br.com.gustavobarbozamarques.mocks.UserRequestDTOMock;
+import br.com.gustavobarbozamarques.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void testListAll() {
+        var usersFromDatabase = List.of(UserMock.get());
+        when(userRepository.findAll()).thenReturn(usersFromDatabase);
+
+        var users = userService.listAll();
+
+        assertThat(users)
+                .isNotEmpty()
+                .hasSize(usersFromDatabase.size());
+        verify(userRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testListByIdShouldReturnUserWhenFound() {
+        var user = UserMock.get();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(user));
+
+        var result = userService.listById(1);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo(user.getName());
+        verify(userRepository, times(1)).findById(anyInt());
+    }
+
+    @Test
+    void testListByIdShouldThrowExceptionWhenNotFound() {
+        when(userRepository.findById(anyInt())).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> userService.listById(1));
+
+        verify(userRepository, times(1)).findById(anyInt());
+    }
+
+    @Test
+    void testSave() {
+        var userToSave = UserMock.get();
+        when(userRepository.save(any(User.class))).thenReturn(userToSave);
+
+        var savedUser = userService.save(UserRequestDTOMock.get());
+
+        assertThat(savedUser).isNotNull();
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    void testUpdateShouldUpdateSuccessfullyWhenUserExists() {
+        var existingUser = UserMock.get();
+        var userDetails = UserRequestDTOMock.get();
+        userDetails.setName("Updated Name");
+
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(existingUser));
+        when(userRepository.save(any(User.class))).thenReturn(existingUser);
+
+        var updatedUser = userService.update(1, userDetails);
+
+        assertThat(updatedUser).isNotNull();
+        assertThat(updatedUser.getName()).isEqualTo("Updated Name");
+        verify(userRepository, times(1)).findById(anyInt());
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    void testUpdateShouldThrowExceptionWhenUserNotFound() {
+        var userDetails = UserRequestDTOMock.get();
+        userDetails.setName("Updated Name");
+
+        when(userRepository.findById(anyInt())).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> userService.update(1, userDetails));
+
+        verify(userRepository, times(1)).findById(anyInt());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void testDelete() {
+        var user = UserMock.get();
+        when(userRepository.findById(anyInt())).thenReturn(Optional.of(user));
+        doNothing().when(userRepository).deleteById(anyInt());
+        userService.delete(1);
+        verify(userRepository, times(1)).deleteById(anyInt());
+    }
+}


### PR DESCRIPTION
This commit introduces the full set of CRUD operations for users, including:
- User entity, DTOs (request and response), repository, and service.
- RESTful API endpoints for user management in UserController.
- Unit tests for user-related services and controllers.
- Initial user data added to .